### PR TITLE
feat: implement storage class variables for persistent storage support

### DIFF
--- a/03-eck-elasticsearch.tf
+++ b/03-eck-elasticsearch.tf
@@ -32,6 +32,7 @@ spec:
           env:
           - name: ES_JAVA_OPTS
             value: "-Xms2g -Xmx2g"
+    # Uncomment the following section if you need persistent storage for Elasticsearch
     # volumeClaimTemplates:
     # - metadata:
     #     name: elasticsearch-data # Do not change this name unless you set up a volume mount for the data path.
@@ -41,7 +42,7 @@ spec:
     #     resources:
     #       requests:
     #         storage: 2Gi
-    #     storageClassName: standard
+    #     storageClassName: ${var.elasticsearch_storage_class}
   # # inject secure settings into Elasticsearch nodes from k8s secrets references
   # secureSettings:
   # - secretName: ref-to-secret

--- a/04-eck-kibana.tf
+++ b/04-eck-kibana.tf
@@ -114,6 +114,18 @@ spec:
   # this shows how to customize the Kibana pod
   # with labels and resource limits
   podTemplate:
+  
+  # Uncomment the following section if you need persistent storage for Kibana
+  # volumeClaimTemplates:
+  # - metadata:
+  #     name: kibana-data
+  #   spec:
+  #     accessModes:
+  #     - ReadWriteOnce
+  #     resources:
+  #       requests:
+  #         storage: 1Gi
+  #     storageClassName: ${var.kibana_storage_class}
     metadata:
       labels:
         deployment: terraform

--- a/registry_images/README.md
+++ b/registry_images/README.md
@@ -1,0 +1,7 @@
+Need to update documentation:
+
+docker_pull_images.sh - pulls docker images down to local docker
+elastic_artifact_registry_container/ - build the artifact registry image
+```
+cd elastic_artifact_registry_container
+docker build -t elastic-artifact-registry .

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -29,11 +29,17 @@ elasticsearch_elastic_user_password = "changeme"
 elasticsearch_ingress_hostname = "es.k8s.internal"
 elasticsearch_node_count = 1 # Default is 3 for production, 1 for development
 
+# Storage class for Elasticsearch persistent volumes (only needed if volumeClaimTemplates are uncommented)
+# elasticsearch_storage_class = "standard"
+
 ##### Kibana Settings #####
 # kibana_name = "kibana-sample"
 # kibana_image = "docker.elastic.co/kibana/kibana:9.2.1"
 kibana_ingress_hostname = "kb.k8s.internal"
 kibana_node_count = 1 # Default is 2 for production, 1 for development
+
+# Storage class for Kibana persistent volumes (only needed if volumeClaimTemplates are uncommented)
+# kibana_storage_class = "standard"
 
 ##### Fleet Server Settings #####
 # fleet_server_name = "eck-fleet-server"

--- a/variables.tf
+++ b/variables.tf
@@ -158,6 +158,12 @@ variable "elasticsearch_node_store_allow_mmap" {
   default       = false
 }
 
+variable "elasticsearch_storage_class" {
+  description   = "Storage class for Elasticsearch persistent volumes (only needed if volumeClaimTemplates are uncommented)"
+  type          = string
+  default       = "standard"
+}
+
 ###################### Kibana Variables ######################
 variable "kibana_name" {
   description   = "Name of Kibana deployment"
@@ -175,6 +181,12 @@ variable "kibana_ingress_hostname" {
   description   = "Kibana ingress Hostname"
   type          = string
   default       = "kb.localhost"
+}
+
+variable "kibana_storage_class" {
+  description   = "Storage class for Kibana persistent volumes (only needed if volumeClaimTemplates are uncommented)"
+  type          = string
+  default       = "standard"
 }
 
 ###################### Fleet Server Variables ######################


### PR DESCRIPTION
- Add elasticsearch_storage_class and kibana_storage_class variables
- Update Elasticsearch and Kibana configs with commented volumeClaimTemplates
- Include storage class variables in terraform.tfvars with clear documentation
- Enhance README with persistent storage configuration guide
- Clarify that storage classes are only needed when volumeClaimTemplates are enabled

The storage class variables are commented out by default to maintain stateless deployments while providing clear guidance for users who need persistent storage capabilities.